### PR TITLE
Refatorando o código usando MIXIN de notificação

### DIFF
--- a/src/components/Formulario.vue
+++ b/src/components/Formulario.vue
@@ -45,11 +45,12 @@
   import TemporizadorComponent from "./Temporizador.vue";
   import { useStore } from "@/store";
   import { TipoNotificacao } from "@/interfaces/INotificacao";
-  import { NOTIFICAR } from "@/store/tipo-mutacoes";
+  import { notificacaoMixin } from "@/mixins/notificar";
 
   export default defineComponent({
     name: "FormularioComponent",
     emits: ["aoSalvarTarefa"],
+    mixins: [notificacaoMixin],
     components: {
       TemporizadorComponent,
     },
@@ -63,12 +64,12 @@
       finalizarTarefa(tempoDecorrido: number): void {
         const projeto = this.projetos.find((p) => p.id == this.idProjeto); // Buscar pelo projeto
         if (!projeto) {
-          // Se o projeto não existeir, então surgirá um alerta
-          this.store.commit(NOTIFICAR, {
-            tipo: TipoNotificacao.ERRO,
-            titulo: "Ops!",
-            texto: "Selecione um projeto antes de finalizar a tarefa!",
-          }); // notificamos o usuário
+          // Se o projeto não existir, então surgirá um alerta
+          this.notificar(
+            TipoNotificacao.ERRO,
+            "Ops!",
+            "Selecione um projeto antes de finalizar a tarefa!"
+          );
           return; // Ao fazer return, o restante do método salvarTarefa não será executado. Técnica de early return
         }
         // Se o projeto existe, então salva a atividade
@@ -85,7 +86,7 @@
     setup() {
       const store = useStore(); // Importar o store e a key
       return {
-        // acessar o state dentro do template
+        // Acessar o state dentro do template
         store, // Adiciona o store ao retorno para que possa ser acessado nos métodos
         projetos: computed(() => store.state.projetos), // Retornar os projetos e é possível
       };

--- a/src/mixins/notificar.ts
+++ b/src/mixins/notificar.ts
@@ -1,0 +1,15 @@
+import { TipoNotificacao } from "@/interfaces/INotificacao";
+import { store } from "@/store";
+import { NOTIFICAR } from "@/store/tipo-mutacoes";
+
+export const notificacaoMixin = {
+    methods: {
+        notificar (tipo: TipoNotificacao, titulo: string, texto: string) : void {
+            store.commit(NOTIFICAR, {
+              tipo,
+              titulo,
+              texto,
+            });
+          },
+    },
+}

--- a/src/views/Projetos/Formulario.vue
+++ b/src/views/Projetos/Formulario.vue
@@ -21,12 +21,9 @@
 
 <script lang="ts">
   import { TipoNotificacao } from "@/interfaces/INotificacao";
+  import { notificacaoMixin } from "@/mixins/notificar";
   import { useStore } from "@/store";
-  import {
-    ADICIONA_PROJETO,
-    ALTERA_PROJETO,
-    NOTIFICAR,
-  } from "@/store/tipo-mutacoes";
+  import { ADICIONA_PROJETO, ALTERA_PROJETO } from "@/store/tipo-mutacoes";
   import { defineComponent } from "vue";
 
   export default defineComponent({
@@ -37,6 +34,7 @@
         type: String,
       },
     },
+    mixins: [notificacaoMixin],
     mounted() {
       // Se tiver id, pega o projeto pelo id
       if (this.id) {
@@ -65,11 +63,11 @@
           this.store.commit(ADICIONA_PROJETO, this.nomeDoProjeto);
         }
         this.nomeDoProjeto = ""; // Limpa o campo de texto
-        this.store.commit(NOTIFICAR, {
-          tipo: TipoNotificacao.SUCESSO,
-          titulo: "Novo projeto adicionado",
-          texto: "O projeto foi salvo com sucesso",
-        });
+        this.notificar(
+          TipoNotificacao.SUCESSO,
+          "Novo projeto adicionado",
+          "O projeto foi salvo com sucesso"
+        );
         this.$router.push("/projetos"); // Redireciona para a página de projetos
       },
     },


### PR DESCRIPTION
Para não ter a necessidade de fazer sempre commit para a store na hora de enviar uma notificação e deixar o código mais limpo, foi criado um MIXIN que cria um método de notificação e fica separado e pode ser reutilizado.
Tem que ter cuidado pois se criar uma função na página que esta usando o mixin com o mesmo nome do mixin, o sistema entrará em conflito